### PR TITLE
Fix README Rust example and enable doctest coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ hash = Chunker.sha256_hash(data)
 ### As Rust Library
 
 ```rust
-use chunker::fastcdc::FastCDC;
+use fastcdc::v2020::FastCDC;
 
 let data = b"data to chunk";
 let chunker = FastCDC::new(data, 16_384, 65_536, 262_144);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,4 @@
-//! # Chunker
-//!
-//! High-performance content-defined chunking (FastCDC) for Nix NARs.
-//!
-//! This library provides:
-//! - FastCDC content-defined chunking algorithm
-//! - Multiple compression codecs (zstd, xz, bzip2)
-//! - Cryptographic signing (Ed25519)
-//! - Hash computation (SHA256, Nix base32)
-//!
-//! When compiled with the `nif` feature, provides Rustler NIF bindings for Elixir.
+#![doc = include_str!("../README.md")]
 
 pub mod chunking;
 pub mod compression;


### PR DESCRIPTION
## Summary
- update the README Rust usage example to import `fastcdc::v2020::FastCDC`
- include the README as crate documentation so its code blocks are exercised as doctests

## Testing
- cargo test --doc


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692784d7a2788332bc6fded7c35841a9)