### PR TITLE
Add bzip2 compression helpers and NIF bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,14 @@ hash = Chunker.sha256_hash(data)
 {:ok, chunks} = Chunker.chunk_data(data, 16_384, 65_536, 262_144)
 
 # Compression/decompression
-{:ok, compressed} = Chunker.compress_zstd(data, 3)
-{:ok, original} = Chunker.decompress_zstd(compressed)
+{:ok, zstd} = Chunker.compress_zstd(data, 3)
+{:ok, original} = Chunker.decompress_zstd(zstd)
+
+{:ok, xz} = Chunker.compress_xz(data, 6)
+{:ok, original} = Chunker.decompress_xz(xz)
+
+{:ok, bzip2} = Chunker.compress_bzip2(data, 6)
+{:ok, original} = Chunker.decompress_bzip2(bzip2)
 
 # Ed25519 signing
 {:ok, {secret_key, public_key}} = Chunker.generate_keypair()
@@ -85,7 +91,7 @@ cargo tarpaulin --out Html --output-dir cover/
 ## Module Structure
 
 - **`chunking.rs`** - FastCDC chunking implementation
-- **`compression.rs`** - zstd/xz/bzip2 compression handlers
+- **`compression.rs`** - zstd/xz/bzip2 compression handlers (size-limited decompression)
 - **`hashing.rs`** - SHA256 and Nix base32 encoding
 - **`signing.rs`** - Ed25519 keypair and signature operations
 - **`lib.rs`** - Rustler NIF initialization

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -83,3 +83,69 @@ pub fn decompress_xz(data: &[u8]) -> Result<Vec<u8>, CompressionError> {
 
     Ok(decompressed)
 }
+
+/// Compress data using `bzip2`
+/// Args: data (binary), `level` (optional, default 6)
+pub fn compress_bzip2(data: &[u8], level: Option<u32>) -> Result<Vec<u8>, CompressionError> {
+    let compression_level = level.unwrap_or(6);
+
+    let mut encoder =
+        bzip2::write::BzEncoder::new(Vec::new(), bzip2::Compression::new(compression_level));
+    encoder
+        .write_all(data)
+        .map_err(|e| CompressionError::Compression(e.to_string()))?;
+
+    let compressed = encoder
+        .finish()
+        .map_err(|e| CompressionError::Compression(e.to_string()))?;
+
+    Ok(compressed)
+}
+
+/// Decompress `bzip2` data
+/// Protected against decompression bombs with `MAX_DECOMPRESSED_SIZE` limit
+pub fn decompress_bzip2(data: &[u8]) -> Result<Vec<u8>, CompressionError> {
+    let decoder = bzip2::read::BzDecoder::new(data);
+    let mut decompressed = Vec::new();
+
+    // Limit reader to MAX_DECOMPRESSED_SIZE to prevent decompression bombs
+    let mut limited_reader = decoder.take(MAX_DECOMPRESSED_SIZE);
+    let _bytes_read = limited_reader
+        .read_to_end(&mut decompressed)
+        .map_err(|e| CompressionError::Decompression(e.to_string()))?;
+
+    // Check if we hit the size limit (indicates potential decompression bomb)
+    if decompressed.len() as u64 == MAX_DECOMPRESSED_SIZE {
+        return Err(CompressionError::SizeExceeded);
+    }
+
+    Ok(decompressed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &[u8] = b"Chunker compression round trip data for testing";
+
+    #[test]
+    fn zstd_round_trip() {
+        let compressed = compress_zstd(SAMPLE, Some(3)).expect("zstd compress");
+        let decompressed = decompress_zstd(&compressed).expect("zstd decompress");
+        assert_eq!(decompressed, SAMPLE);
+    }
+
+    #[test]
+    fn xz_round_trip() {
+        let compressed = compress_xz(SAMPLE, Some(6)).expect("xz compress");
+        let decompressed = decompress_xz(&compressed).expect("xz decompress");
+        assert_eq!(decompressed, SAMPLE);
+    }
+
+    #[test]
+    fn bzip2_round_trip() {
+        let compressed = compress_bzip2(SAMPLE, Some(6)).expect("bzip2 compress");
+        let decompressed = decompress_bzip2(&compressed).expect("bzip2 decompress");
+        assert_eq!(decompressed, SAMPLE);
+    }
+}

--- a/src/nif.rs
+++ b/src/nif.rs
@@ -21,6 +21,8 @@ mod atoms {
         zstd_decompression_failed,
         xz_compression_failed,
         xz_decompression_failed,
+        bzip2_compression_failed,
+        bzip2_decompression_failed,
         chunk_bounds_invalid,
     }
 }
@@ -39,6 +41,8 @@ rustler::init!(
         decompress_zstd,
         compress_xz,
         decompress_xz,
+        compress_bzip2,
+        decompress_bzip2,
         chunk_data
     ]
 );
@@ -166,6 +170,26 @@ fn decompress_xz<'a>(env: Env<'a>, data: Binary<'a>) -> NifResult<Binary<'a>> {
         Ok(decompressed) => binary_from_vec(env, decompressed),
         Err(_) => Err(rustler::error::Error::Term(Box::new(
             atoms::xz_decompression_failed(),
+        ))),
+    }
+}
+
+#[rustler::nif]
+fn compress_bzip2<'a>(env: Env<'a>, data: Binary<'a>, level: Option<u32>) -> NifResult<Binary<'a>> {
+    match compression::compress_bzip2(data.as_slice(), level) {
+        Ok(compressed) => binary_from_vec(env, compressed),
+        Err(_) => Err(rustler::error::Error::Term(Box::new(
+            atoms::bzip2_compression_failed(),
+        ))),
+    }
+}
+
+#[rustler::nif]
+fn decompress_bzip2<'a>(env: Env<'a>, data: Binary<'a>) -> NifResult<Binary<'a>> {
+    match compression::decompress_bzip2(data.as_slice()) {
+        Ok(decompressed) => binary_from_vec(env, decompressed),
+        Err(_) => Err(rustler::error::Error::Term(Box::new(
+            atoms::bzip2_decompression_failed(),
         ))),
     }
 }


### PR DESCRIPTION
## Summary
- add bzip2 compression/decompression helpers with size-limited safety checks
- expose bzip2 operations through Rustler NIFs with corresponding error atoms
- document available compression options and add round-trip unit tests

## Testing
- cargo test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692784ddb5148332ba6c807eea018bda)