### PR TITLE
Add streaming chunk reader support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ default = []
 # build focused on the pure Rust library. Enable with `--features nif` when
 # building the NIF cdylib for Elixir.
 nif = ["rustler"]
+async-stream = ["futures"]
 
 [lib]
 name = "chunker"
@@ -44,6 +45,9 @@ fastcdc = "3.2.1"
 # Serialization
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
+
+# Async compatibility for streaming chunkers
+futures = { version = "0.3", optional = true }
 
 # Random number generation for key generation
 # Using 0.8 for compatibility with ed25519-dalek 2.2 (requires rand_core 0.6)

--- a/README.md
+++ b/README.md
@@ -40,11 +40,21 @@ hash = Chunker.sha256_hash(data)
 
 ```rust
 use chunker::fastcdc::FastCDC;
+use chunker::chunking::ChunkStream;
+use std::io::BufReader;
 
 let data = b"data to chunk";
 let chunker = FastCDC::new(data, 16_384, 65_536, 262_144);
 for chunk in chunker {
     println!("Chunk at {}: {} bytes", chunk.offset, chunk.length);
+}
+
+// Stream large inputs without holding everything in memory
+let file = BufReader::new(std::fs::File::open("/path/to/large.nar")?);
+let stream = ChunkStream::new(file, None, None, None);
+for chunk in stream {
+    let chunk = chunk?;
+    println!("Streaming chunk at {}: {} bytes (hash: {})", chunk.offset, chunk.length, chunk.hash);
 }
 ```
 

--- a/src/chunking.rs
+++ b/src/chunking.rs
@@ -1,7 +1,14 @@
-use fastcdc::v2020::FastCDC;
+use fastcdc::v2020::{FastCDC, StreamCDC};
 use sha2::{Digest, Sha256};
+use std::fmt;
+use std::io::Read;
 
-#[derive(Debug, thiserror::Error, Clone, Copy)]
+#[cfg(feature = "async-stream")]
+use futures::io::AsyncRead;
+#[cfg(feature = "async-stream")]
+use futures::io::AsyncReadExt;
+
+#[derive(Debug, thiserror::Error)]
 pub enum ChunkingError {
     #[error(
         "bounds_check_failed: offset {offset} + length {length} exceeds data length {data_len}"
@@ -11,6 +18,40 @@ pub enum ChunkingError {
         offset: usize,
         length: usize,
     },
+    #[error("io_error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Metadata for a single chunk emitted by streaming chunkers.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ChunkMetadata {
+    /// Hex-encoded SHA-256 hash of the chunk payload.
+    pub hash: String,
+    /// Starting byte offset of the chunk relative to the reader.
+    pub offset: u64,
+    /// Chunk length in bytes.
+    pub length: usize,
+}
+
+/// Configurable bounds for FastCDC chunking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ChunkingOptions {
+    /// Minimum chunk size in bytes.
+    pub min_size: usize,
+    /// Average (target) chunk size in bytes.
+    pub avg_size: usize,
+    /// Maximum chunk size in bytes.
+    pub max_size: usize,
+}
+
+impl ChunkingOptions {
+    fn resolve(min_size: Option<usize>, avg_size: Option<usize>, max_size: Option<usize>) -> Self {
+        Self {
+            min_size: min_size.unwrap_or(16_384),
+            avg_size: avg_size.unwrap_or(65_536),
+            max_size: max_size.unwrap_or(262_144),
+        }
+    }
 }
 
 /// Validate slice bounds to prevent out-of-bounds access
@@ -39,13 +80,15 @@ pub fn chunk_data(
     avg_size: Option<usize>,
     max_size: Option<usize>,
 ) -> Result<Vec<(String, usize, usize)>, ChunkingError> {
+    let options = ChunkingOptions::resolve(min_size, avg_size, max_size);
+
     // These values are well below u32::MAX, so truncation is safe
     #[allow(clippy::cast_possible_truncation)]
-    let min = min_size.unwrap_or(16_384) as u32; // 16 KB
+    let min = options.min_size as u32; // 16 KB
     #[allow(clippy::cast_possible_truncation)]
-    let avg = avg_size.unwrap_or(65_536) as u32; // 64 KB
+    let avg = options.avg_size as u32; // 64 KB
     #[allow(clippy::cast_possible_truncation)]
-    let max = max_size.unwrap_or(262_144) as u32; // 256 KB
+    let max = options.max_size as u32; // 256 KB
 
     let chunker = FastCDC::new(data, min, avg, max);
 
@@ -65,4 +108,140 @@ pub fn chunk_data(
     }
 
     Ok(chunks)
+}
+
+/// A streaming chunk reader that yields chunk metadata and hashes without buffering
+/// the entire source in memory.
+pub struct ChunkStream<R: Read> {
+    inner: StreamCDC<R>,
+}
+
+impl<R: Read> fmt::Debug for ChunkStream<R> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ChunkStream")
+            .field("offset", &"streaming")
+            .finish()
+    }
+}
+
+impl<R: Read> ChunkStream<R> {
+    /// Create a streaming chunker around any [`std::io::Read`] implementation.
+    /// Uses FastCDC with optional min/avg/max overrides.
+    pub fn new(reader: R, min_size: Option<usize>, avg_size: Option<usize>, max_size: Option<usize>) -> Self {
+        let options = ChunkingOptions::resolve(min_size, avg_size, max_size);
+
+        #[allow(clippy::cast_possible_truncation)]
+        let min = options.min_size as u32;
+        #[allow(clippy::cast_possible_truncation)]
+        let avg = options.avg_size as u32;
+        #[allow(clippy::cast_possible_truncation)]
+        let max = options.max_size as u32;
+
+        let inner = StreamCDC::new(reader, min, avg, max);
+        Self { inner }
+    }
+}
+
+impl<R: Read> Iterator for ChunkStream<R> {
+    type Item = Result<ChunkMetadata, ChunkingError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let chunk_result = self.inner.next()?;
+        match chunk_result {
+            Ok(chunk) => {
+                let mut hasher = Sha256::new();
+                hasher.update(&chunk.data);
+                let hash_hex = hex::encode(hasher.finalize());
+
+                Some(Ok(ChunkMetadata {
+                    hash: hash_hex,
+                    offset: chunk.offset,
+                    length: chunk.length,
+                }))
+            }
+            Err(err) => Some(Err(ChunkingError::Io(err.into()))),
+        }
+    }
+}
+
+/// Adapter to allow [`ChunkStream`] usage with asynchronous readers.
+#[cfg(feature = "async-stream")]
+pub struct AsyncReadAdapter<R: AsyncRead + Unpin> {
+    inner: R,
+}
+
+#[cfg(feature = "async-stream")]
+impl<R: AsyncRead + Unpin> fmt::Debug for AsyncReadAdapter<R> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AsyncReadAdapter").finish()
+    }
+}
+
+#[cfg(feature = "async-stream")]
+impl<R: AsyncRead + Unpin> Read for AsyncReadAdapter<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        futures::executor::block_on(self.inner.read(buf))
+    }
+}
+
+/// A convenience alias that exposes streaming chunking for any [`AsyncRead`]
+/// implementor under the `async-stream` feature flag.
+#[cfg(feature = "async-stream")]
+pub type AsyncChunkStream<R> = ChunkStream<AsyncReadAdapter<R>>;
+
+/// Construct a [`ChunkStream`] around an asynchronous reader by blocking on
+/// individual reads. This keeps the same low-memory chunking behavior while
+/// allowing consumers in async contexts to feed data into FastCDC.
+#[cfg(feature = "async-stream")]
+pub fn chunk_stream_async<R: AsyncRead + Unpin>(
+    reader: R,
+    min_size: Option<usize>,
+    avg_size: Option<usize>,
+    max_size: Option<usize>,
+) -> AsyncChunkStream<R> {
+    ChunkStream::new(AsyncReadAdapter { inner: reader }, min_size, avg_size, max_size)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufReader, Cursor};
+
+    #[test]
+    fn streaming_reader_emits_full_length() -> Result<(), ChunkingError> {
+        let size = 3 * 1024 * 1024 + 321; // Just over 3 MiB
+        let data = vec![42_u8; size];
+        let cursor = Cursor::new(&data);
+        let reader = BufReader::new(cursor);
+
+        let mut stream = ChunkStream::new(reader, None, Some(32 * 1024), Some(64 * 1024));
+        let mut total = 0_usize;
+        let mut count = 0_usize;
+
+        while let Some(chunk) = stream.next() {
+            let chunk = chunk?;
+            total += chunk.length;
+            count += 1;
+        }
+
+        assert_eq!(total, size);
+        assert!(count > 1); // Ensure multiple chunks were produced for large data
+
+        Ok(())
+    }
+
+    #[test]
+    fn chunking_options_defaults_match_chunk_data() -> Result<(), ChunkingError> {
+        let payload = b"streaming chunker parity test".repeat(2048);
+        let mut streaming = ChunkStream::new(Cursor::new(&payload), None, None, None);
+        let collected: Vec<_> = streaming
+            .by_ref()
+            .map(|res| res.map(|chunk| (chunk.hash, chunk.offset as usize, chunk.length)))
+            .collect::<Result<_, _>>()?;
+
+        let eager = chunk_data(&payload, None, None, None)?;
+        assert_eq!(collected, eager);
+
+        Ok(())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ pub mod compression;
 pub mod hashing;
 pub mod signing;
 
+pub use chunking::{ChunkMetadata, ChunkStream, ChunkingOptions};
+
 #[cfg(feature = "nif")]
 pub mod nif;
 

--- a/src/nif.rs
+++ b/src/nif.rs
@@ -5,6 +5,7 @@ use rustler::types::binary::OwnedBinary;
 use rustler::{Binary, Env, NifResult};
 
 use crate::{chunking, compression, hashing, signing};
+use std::io::Cursor;
 
 mod atoms {
     rustler::atoms! {
@@ -39,7 +40,8 @@ rustler::init!(
         decompress_zstd,
         compress_xz,
         decompress_xz,
-        chunk_data
+        chunk_data,
+        chunk_data_streaming
     ]
 );
 fn binary_from_vec<'a>(env: Env<'a>, data: Vec<u8>) -> NifResult<Binary<'a>> {
@@ -200,5 +202,45 @@ fn chunk_data<'a>(
         Err(chunking::ChunkingError::Bounds { .. }) => Err(rustler::error::Error::Term(Box::new(
             atoms::chunk_bounds_invalid(),
         ))),
+        Err(chunking::ChunkingError::Io(_)) => Err(rustler::error::Error::Term(Box::new(
+            atoms::chunk_bounds_invalid(),
+        ))),
     }
+}
+
+#[rustler::nif]
+fn chunk_data_streaming<'a>(
+    _env: Env<'a>,
+    data: Binary<'a>,
+    min_size: Option<u32>,
+    avg_size: Option<u32>,
+    max_size: Option<u32>,
+) -> NifResult<Vec<(String, u32, u32)>> {
+    let min = min_size.unwrap_or(16_384) as usize;
+    let avg = avg_size.unwrap_or(65_536) as usize;
+    let max = max_size.unwrap_or(262_144) as usize;
+
+    let cursor = Cursor::new(data.as_slice());
+    let stream = chunking::ChunkStream::new(cursor, Some(min), Some(avg), Some(max));
+
+    let mut chunks = Vec::new();
+    for chunk in stream {
+        let chunk = chunk.map_err(|err| match err {
+            chunking::ChunkingError::Bounds { .. } => {
+                rustler::error::Error::Term(Box::new(atoms::chunk_bounds_invalid()))
+            }
+            chunking::ChunkingError::Io(_) => {
+                rustler::error::Error::Term(Box::new(atoms::chunk_bounds_invalid()))
+            }
+        })?;
+
+        #[allow(clippy::cast_possible_truncation)]
+        let offset_u32 = chunk.offset as u32;
+        #[allow(clippy::cast_possible_truncation)]
+        let length_u32 = chunk.length as u32;
+
+        chunks.push((chunk.hash, offset_u32, length_u32));
+    }
+
+    Ok(chunks)
 }


### PR DESCRIPTION
## Summary
- add streaming ChunkStream and metadata types to chunk large inputs incrementally
- expose streaming chunking via public API, README examples, and new NIF entrypoint
- introduce optional async-stream feature for AsyncRead adapters and parity tests

## Testing
- cargo test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692784e4dc308332a21c687f2842bc22)