### PR TITLE
Add ingest metrics hooks and window policy adjustments

### DIFF
--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1,0 +1,195 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::chunking::{chunk_data, ChunkingError};
+use crate::compression::{compress_zstd, CompressionError};
+
+#[derive(Debug, thiserror::Error)]
+pub enum IngestError {
+    #[error(transparent)]
+    Chunking(#[from] ChunkingError),
+    #[error(transparent)]
+    Compression(#[from] CompressionError),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WindowConfig {
+    pub min: usize,
+    pub avg: usize,
+    pub max: usize,
+}
+
+impl WindowConfig {
+    pub fn with_defaults() -> Self {
+        Self {
+            min: 16_384,
+            avg: 65_536,
+            max: 262_144,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Artifact<'a> {
+    pub path: &'a str,
+    pub class: &'a str,
+    pub data: &'a [u8],
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct MetricSnapshot {
+    pub reused_chunks: usize,
+    pub total_chunks: usize,
+    pub compressed_bytes: usize,
+    pub uncompressed_bytes: usize,
+}
+
+impl MetricSnapshot {
+    pub fn reuse_ratio(&self) -> f64 {
+        if self.total_chunks == 0 {
+            return 0.0;
+        }
+        self.reused_chunks as f64 / self.total_chunks as f64
+    }
+
+    pub fn compression_ratio(&self) -> f64 {
+        if self.uncompressed_bytes == 0 {
+            return 0.0;
+        }
+        self.compressed_bytes as f64 / self.uncompressed_bytes as f64
+    }
+
+    pub fn merge(&mut self, other: &MetricSnapshot) {
+        self.reused_chunks += other.reused_chunks;
+        self.total_chunks += other.total_chunks;
+        self.compressed_bytes += other.compressed_bytes;
+        self.uncompressed_bytes += other.uncompressed_bytes;
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct IngestMetrics {
+    pub per_path: HashMap<String, MetricSnapshot>,
+    pub per_class: HashMap<String, MetricSnapshot>,
+}
+
+impl IngestMetrics {
+    fn record(&mut self, path: &str, class: &str, snapshot: MetricSnapshot) {
+        let _ = self.per_path.insert(path.to_string(), snapshot);
+
+        let entry = self
+            .per_class
+            .entry(class.to_string())
+            .or_insert_with(MetricSnapshot::default);
+        entry.merge(&snapshot);
+    }
+
+    pub fn class_metrics(&self, class: &str) -> Option<&MetricSnapshot> {
+        self.per_class.get(class)
+    }
+}
+
+#[derive(Debug)]
+pub struct Ingestor {
+    window_config: WindowConfig,
+    chunk_index: HashSet<String>,
+    pub metrics: IngestMetrics,
+}
+
+impl Ingestor {
+    pub fn new(window_config: WindowConfig) -> Self {
+        Self {
+            window_config,
+            chunk_index: HashSet::new(),
+            metrics: IngestMetrics::default(),
+        }
+    }
+
+    pub fn ingest(&mut self, artifact: Artifact<'_>) -> Result<MetricSnapshot, IngestError> {
+        let cfg = self.window_config;
+        let chunks = chunk_data(artifact.data, Some(cfg.min), Some(cfg.avg), Some(cfg.max))?;
+
+        let reused_chunks = chunks
+            .iter()
+            .filter(|(hash, _, _)| self.chunk_index.contains(hash))
+            .count();
+
+        for (hash, _, _) in &chunks {
+            let _ = self.chunk_index.insert(hash.clone());
+        }
+
+        let compressed = compress_zstd(artifact.data, Some(3))?;
+        let snapshot = MetricSnapshot {
+            reused_chunks,
+            total_chunks: chunks.len(),
+            compressed_bytes: compressed.len(),
+            uncompressed_bytes: artifact.data.len(),
+        };
+
+        self.metrics
+            .record(artifact.path, artifact.class, snapshot.clone());
+
+        Ok(snapshot)
+    }
+
+    pub fn set_window_config(&mut self, window_config: WindowConfig) {
+        self.window_config = window_config;
+    }
+
+    pub fn window_config(&self) -> WindowConfig {
+        self.window_config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_data(prefix: u8, len: usize) -> Vec<u8> {
+        std::iter::repeat(prefix).take(len).collect()
+    }
+
+    #[test]
+    fn records_metrics_per_path_and_class() {
+        let mut ingestor = Ingestor::new(WindowConfig {
+            min: 1024,
+            avg: 2048,
+            max: 4096,
+        });
+
+        let artifact_a = Artifact {
+            path: "logs/app.log",
+            class: "log",
+            data: &sample_data(b'A', 10 * 1024),
+        };
+
+        let artifact_b = Artifact {
+            path: "artifacts/bin",
+            class: "binary",
+            data: &sample_data(b'B', 8 * 1024),
+        };
+
+        let snapshot_a = ingestor.ingest(artifact_a).expect("ingest A");
+        let snapshot_b = ingestor.ingest(artifact_b).expect("ingest B");
+
+        assert!(snapshot_a.total_chunks > 0);
+        assert!(snapshot_b.total_chunks > 0);
+
+        let log_metrics = ingestor
+            .metrics
+            .per_path
+            .get("logs/app.log")
+            .expect("log metrics recorded");
+        assert_eq!(log_metrics.total_chunks, snapshot_a.total_chunks);
+
+        let class_metrics = ingestor
+            .metrics
+            .class_metrics("log")
+            .expect("class metrics aggregated");
+        assert_eq!(class_metrics.total_chunks, snapshot_a.total_chunks);
+        assert_eq!(class_metrics.reused_chunks, snapshot_a.reused_chunks);
+        assert_eq!(
+            class_metrics.uncompressed_bytes,
+            snapshot_a.uncompressed_bytes
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@
 pub mod chunking;
 pub mod compression;
 pub mod hashing;
+pub mod ingest;
+pub mod policy;
 pub mod signing;
 
 #[cfg(feature = "nif")]

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,0 +1,172 @@
+use std::collections::HashMap;
+
+use crate::ingest::{MetricSnapshot, WindowConfig};
+
+#[derive(Clone, Copy, Debug)]
+pub struct WindowBounds {
+    pub min: WindowConfig,
+    pub max: WindowConfig,
+}
+
+impl WindowBounds {
+    pub fn clamp(&self, config: WindowConfig) -> WindowConfig {
+        WindowConfig {
+            min: config.min.clamp(self.min.min, self.max.min),
+            avg: config.avg.clamp(self.min.avg, self.max.avg),
+            max: config.max.clamp(self.min.max, self.max.max),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct WindowPolicy {
+    base: WindowConfig,
+    bounds: WindowBounds,
+    reuse_growth_threshold: f64,
+    reuse_shrink_threshold: f64,
+    compression_growth_threshold: f64,
+    compression_shrink_threshold: f64,
+    per_class: HashMap<String, WindowConfig>,
+}
+
+impl WindowPolicy {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        base: WindowConfig,
+        bounds: WindowBounds,
+        reuse_growth_threshold: f64,
+        reuse_shrink_threshold: f64,
+        compression_growth_threshold: f64,
+        compression_shrink_threshold: f64,
+    ) -> Self {
+        Self {
+            base,
+            bounds,
+            reuse_growth_threshold,
+            reuse_shrink_threshold,
+            compression_growth_threshold,
+            compression_shrink_threshold,
+            per_class: HashMap::new(),
+        }
+    }
+
+    pub fn config_for_class(&self, class: &str) -> WindowConfig {
+        *self.per_class.get(class).unwrap_or(&self.base)
+    }
+
+    pub fn observe(&mut self, class: &str, metrics: &MetricSnapshot) -> WindowConfig {
+        let mut current = self.config_for_class(class);
+        let reuse_ratio = metrics.reuse_ratio();
+        let compression_ratio = metrics.compression_ratio();
+
+        // Deterministic adjustments: only shrink/grow in fixed increments based on thresholds.
+        if reuse_ratio < self.reuse_shrink_threshold
+            || compression_ratio > self.compression_shrink_threshold
+        {
+            current = self.shrink(current);
+        } else if reuse_ratio > self.reuse_growth_threshold
+            && compression_ratio < self.compression_growth_threshold
+        {
+            current = self.grow(current);
+        }
+
+        current = self.bounds.clamp(current);
+        let _ = self.per_class.insert(class.to_string(), current);
+        current
+    }
+
+    fn shrink(&self, current: WindowConfig) -> WindowConfig {
+        WindowConfig {
+            min: (current.min / 2).max(self.bounds.min.min),
+            avg: (current.avg * 3 / 4).max(self.bounds.min.avg),
+            max: (current.max * 3 / 4).max(self.bounds.min.max),
+        }
+    }
+
+    fn grow(&self, current: WindowConfig) -> WindowConfig {
+        WindowConfig {
+            min: (current.min * 3 / 2).min(self.bounds.max.min),
+            avg: (current.avg * 3 / 2).min(self.bounds.max.avg),
+            max: (current.max * 3 / 2).min(self.bounds.max.max),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ingest::{Artifact, Ingestor};
+
+    fn make_dataset(with_insertion: bool) -> Vec<u8> {
+        let mut data: Vec<u8> = Vec::new();
+        for i in 0..80 {
+            let byte = if i % 9 == 0 { b'B' } else { b'A' };
+            data.extend(std::iter::repeat(byte).take(1024));
+        }
+
+        if with_insertion {
+            let insertion = vec![b'Z'; 512];
+            let _ = data.splice(12 * 1024..12 * 1024, insertion);
+        }
+
+        data
+    }
+
+    fn ingest_pair(config: WindowConfig) -> MetricSnapshot {
+        let mut ingestor = Ingestor::new(config);
+        let base = Artifact {
+            path: "logs/app.log",
+            class: "log",
+            data: &make_dataset(false),
+        };
+        let shifted = Artifact {
+            path: "logs/app.log",
+            class: "log",
+            data: &make_dataset(true),
+        };
+
+        let _ = ingestor.ingest(base).expect("first ingest");
+        ingestor.ingest(shifted).expect("second ingest")
+    }
+
+    #[test]
+    fn policy_adjusts_windows_and_improves_reuse() {
+        let base = WindowConfig {
+            min: 4_096,
+            avg: 8_192,
+            max: 16_384,
+        };
+        let bounds = WindowBounds {
+            min: WindowConfig {
+                min: 1_024,
+                avg: 2_048,
+                max: 4_096,
+            },
+            max: WindowConfig {
+                min: 32_768,
+                avg: 65_536,
+                max: 98_304,
+            },
+        };
+
+        let mut policy = WindowPolicy::new(base, bounds, 0.75, 0.35, 0.6, 0.8);
+
+        let baseline_metrics = ingest_pair(base);
+        let next_config = policy.observe("log", &baseline_metrics);
+        assert!(
+            next_config.avg < base.avg,
+            "expected shrink toward finer windows"
+        );
+
+        let improved_metrics = ingest_pair(next_config);
+
+        assert!(
+            improved_metrics.reuse_ratio() > baseline_metrics.reuse_ratio(),
+            "smaller windows should reuse more chunks after insertion shift"
+        );
+        assert!(
+            improved_metrics.compression_ratio() <= baseline_metrics.compression_ratio(),
+            "smaller windows should not regress compression on repeating data"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add ingest module to capture chunk reuse and compression metrics per path and artifact class
- implement deterministic window policy that grows or shrinks chunking windows based on observed stability
- add simulations demonstrating improved reuse and compression behavior after policy adjustments

## Testing
- cargo test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69278a2b215083329578a1dfe39fd636)