### PR TITLE
Add BLAKE3 hashing option and benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ default = []
 # build focused on the pure Rust library. Enable with `--features nif` when
 # building the NIF cdylib for Elixir.
 nif = ["rustler"]
+blake3 = ["dep:blake3"]
 
 [lib]
 name = "chunker"
@@ -32,6 +33,7 @@ thiserror = "1.0"
 # Cryptography
 ed25519-dalek = { version = "2.2", features = ["rand_core"] }
 sha2 = "0.10.9"
+blake3 = { version = "1.5.4", optional = true }
 
 # Compression
 zstd = "0.13.3"
@@ -54,6 +56,13 @@ hex = "0.4.3"
 
 # Base64 encoding with strict padding validation
 base64 = "0.22.1"
+
+[dev-dependencies]
+criterion = { version = "0.5", default-features = false, features = ["html_reports", "cargo_bench_support"] }
+
+[[bench]]
+name = "hashing_benchmarks"
+harness = false
 
 # =============================================================================
 # Enterprise-Grade Clippy Lints Configuration

--- a/benches/hashing_benchmarks.rs
+++ b/benches/hashing_benchmarks.rs
@@ -1,0 +1,42 @@
+use chunker::{chunking, hashing::HashAlgorithm};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+
+fn chunk_hashing_benchmarks(c: &mut Criterion) {
+    let data = vec![1u8; 2 * 1024 * 1024];
+    let mut group = c.benchmark_group("chunking_hashing");
+    group.throughput(Throughput::Bytes(data.len() as u64));
+
+    group.bench_function("sha256", |b| {
+        b.iter(|| {
+            let chunks = chunking::chunk_data_with_hasher(
+                black_box(&data),
+                None,
+                None,
+                None,
+                HashAlgorithm::Sha256,
+            )
+            .expect("chunking should succeed");
+            black_box(chunks);
+        });
+    });
+
+    #[cfg(feature = "blake3")]
+    group.bench_function("blake3", |b| {
+        b.iter(|| {
+            let chunks = chunking::chunk_data_with_hasher(
+                black_box(&data),
+                None,
+                None,
+                None,
+                HashAlgorithm::Blake3,
+            )
+            .expect("chunking should succeed");
+            black_box(chunks);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, chunk_hashing_benchmarks);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- add optional blake3 feature with helper and unified hash selection enum
- allow chunking APIs and NIF bindings to choose hash algorithm while defaulting to SHA-256
- add Criterion benchmarks comparing SHA-256 and BLAKE3 chunk hashing

## Testing
- cargo test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69278a2923108332aeb9362ae7b8cf46)