### PR TITLE
chore: release 0.1.0-beta2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,3 +136,33 @@ jobs:
           nix develop .#default --command bash -c "\
             cargo fmt --all -- --check\
           "
+
+  publish-cargo:
+    name: Publish to GitHub Cargo Registry
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    needs: [test, test-telemetry, test-nif, clippy, fmt]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Configure private registry
+        run: |
+          mkdir -p ~/.cargo
+          cat <<'EOF' > ~/.cargo/config.toml
+          [registries.flakecache]
+          index = "sparse+https://github.com/FlakeCache/_cargo-index.git"
+          EOF
+
+      - name: Publish crate
+        env:
+          CARGO_REGISTRIES_FLAKECACHE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cargo publish --registry flakecache

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "chunker"
-version = "0.1.0-beta1"
+version = "0.1.0-beta2"
 authors = ["FlakeCache Team"]
 edition = "2024"
-publish = false
 description = "High-performance content-defined chunking for Nix NARs (Rustler NIF + standalone library)"
 repository = "https://github.com/FlakeCache/chunker"
 homepage = "https://github.com/FlakeCache/chunker"


### PR DESCRIPTION
- bump crate to 0.1.0-beta2
- add GHCR Cargo publish job on release